### PR TITLE
Updated the package to support laravel elixir v3.0 and above

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,22 @@
 'use strict';
 
 var gulp = require('gulp');
-var elixir = require('laravel-elixir');
+var Elixir = require('laravel-elixir');
 var _ = require('underscore');
 var apidoc = require('gulp-apidoc');
 
-elixir.extend('apidoc', function (options) {
+Elixir.extend('apidoc', function (options) {
 
-    var opts = _.extend({
+    options = _.extend({
         src: 'app/',
-        dest: 'docs/api'
+        dest: 'public/docs/api'
     }, options);
 
-    gulp.task('apidoc', function () {
-        apidoc.exec(opts);
-    });
+    new Elixir.Task('apidoc', function () {
+        apidoc.exec({
+            src: options.src,
+            dest: options.dest
+        });
+    }).watch(options.src + '**/*.php');
 
-    return this.queueTask('apidoc');
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "laravel-elixir-apidoc",
   "description": "Build style guide with hologram.",
+  "version": "0.1.3",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Elixir version 3.0 introduced a new syntax for creating extensions: https://github.com/laravel/elixir/releases/tag/3.0.0

Changes:
- Updated the package to support the new extension syntax introduced in elixir version 3.0 (Released in July 2015)
- Support for gulp watch
- Changed the default dest directory to public/docs/api
